### PR TITLE
changed to gettext_lazy because of deprecation

### DIFF
--- a/hcaptcha/fields.py
+++ b/hcaptcha/fields.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 from urllib.request import build_opener, Request, ProxyHandler
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from hcaptcha.settings import DEFAULT_CONFIG, PROXIES, SECRET, TIMEOUT, VERIFY_URL
 from hcaptcha.widgets import hCaptchaWidget


### PR DESCRIPTION
There is a deprecation hint since Django 3.0 for the usage of ugettext_lazy as seen here https://docs.djangoproject.com/en/3.0/releases/3.0/#id3

Replacing them with the gettext counterpart should be done.